### PR TITLE
Copy theme to ghost install folder on change

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@ var customProperties = require('postcss-custom-properties');
 var easyimport = require('postcss-easy-import');
 
 // Ghost theme install path
-var ghostThemePath = '../ghost-test/content/themes/dpdc';
+var ghostThemePath = '<local_ghost_install_folder>/content/themes/dpdc';
 
 var swallowError = function swallowError(error) {
   gutil.log(error.toString());


### PR DESCRIPTION
👍🏽 Removes the need to zip and upload the theme after each change.
👎🏽 Still requires you to refresh your browser. 

To use, replace set `ghostThemePath` in `gulpfile.js` to your install path.